### PR TITLE
feat: capacity-aware availability allocation for supplier booking validation

### DIFF
--- a/backend/src/common/validation/supplier/services/validation/Booker.ts
+++ b/backend/src/common/validation/supplier/services/validation/Booker.ts
@@ -24,8 +24,8 @@ export class Booker {
 
     const productId = params?.invalidProductId ? context.invalidProductId : product.id;
     const optionId = params?.invalidOptionId ? context.invalidOptionId : productBookable.getOption().id;
-    const availabilityId = this.getAvailabilityId(productBookable, context, params);
     const unitItems = this.getUnitItems(productBookable, params);
+    const availabilityId = this.getAvailabilityId(productBookable, context, unitItems, params);
 
     const data = {
       productId,
@@ -42,6 +42,7 @@ export class Booker {
   private getAvailabilityId(
     productBookable: ProductBookable,
     context: Context,
+    unitItems: BookingUnitItem[] | null,
     params?: CreateReservationParams,
   ): string | null {
     if (params?.invalidAvailabilityId) {
@@ -49,7 +50,9 @@ export class Booker {
     } else if (params?.soldOutAvailability) {
       return productBookable.availabilityIdSoldOut;
     }
-    return productBookable.randomAvailabilityID;
+    // Allocate a slot with enough vacancy for this reservation's units so the run spreads
+    // across slots instead of exhausting one (see docs/reservation-availability-refactor.md).
+    return productBookable.reserveSlot(Math.max(unitItems?.length ?? 1, 1));
   }
 
   private getUnitItems(productBookable: ProductBookable, params?: CreateReservationParams): BookingUnitItem[] | null {

--- a/backend/src/common/validation/supplier/services/validation/Controller.ts
+++ b/backend/src/common/validation/supplier/services/validation/Controller.ts
@@ -1,5 +1,6 @@
 import { inject } from '@needle-di/core';
 import { SupplierRequestLogService } from '../../../../requestLog/supplier/SupplierRequestLogService';
+import { ErrorType, ValidatorError } from '../../validators/backendValidator/ValidatorHelpers';
 import { Context } from './context/Context';
 import { AvailabilityCalendarFlow } from './Flows/Availability/AvailabilityCalendarFlow';
 import { AvailabilityFlow } from './Flows/Availability/AvailabilityFlow';
@@ -13,17 +14,20 @@ import { BookingUpdateFlow } from './Flows/Booking/BookingUpdateFlow';
 import { Flow, FlowResult } from './Flows/Flow';
 import { ProductFlow } from './Flows/Product/ProductFlow';
 import { SupplierFlow } from './Flows/Supplier/SupplierFlow';
+import { ScenarioResult, ValidationResult } from './Scenarios/Scenario';
 
 export class ValidationController {
   public constructor(private readonly supplierRequestLogService = inject(SupplierRequestLogService)) {}
 
   public validate = async (context: Context): Promise<FlowResult[]> => {
-    const flows: Flow[] = [
+    const setupFlows: Flow[] = [
       // new CapabilitiesFlow(),
       new SupplierFlow(),
       new ProductFlow(),
       new AvailabilityCalendarFlow(),
       new AvailabilityFlow(),
+    ];
+    const bookingFlows: Flow[] = [
       new BookingReservationFlow(),
       new BookingExtendFlow(),
       new BookingConfirmationFlow(),
@@ -32,21 +36,97 @@ export class ValidationController {
       new BookingGetFlow(),
       new BookingListFlow(),
     ];
-    const results = [];
+    const results: FlowResult[] = [];
 
-    for await (const flow of flows) {
+    const runFlow = async (flow: Flow): Promise<void> => {
       const result = await flow.validate(context);
       results.push(result);
-
       for (const scenario of result.scenarios) {
-        this.supplierRequestLogService.logScenario(scenario, context);
+        await this.supplierRequestLogService.logScenario(scenario, context);
       }
+    };
 
+    for (const flow of setupFlows) {
+      await runFlow(flow);
+      if (context.terminateValidation) {
+        return results;
+      }
+    }
+
+    // Before running the booking lifecycle, make sure the supplier exposes enough availability to
+    // satisfy every reservation the booking flows will make (see
+    // docs/reservation-availability-refactor.md). Otherwise the run would exhaust capacity midway
+    // and report misleading per-scenario failures.
+    const capacityResult = this.checkAvailabilityCapacity(context, bookingFlows);
+    if (capacityResult !== null) {
+      results.push(capacityResult);
+      for (const scenario of capacityResult.scenarios) {
+        await this.supplierRequestLogService.logScenario(scenario, context);
+      }
+      if (context.terminateValidation) {
+        return results;
+      }
+    }
+
+    for (const flow of bookingFlows) {
+      await runFlow(flow);
       if (context.terminateValidation) {
         break;
       }
     }
 
     return results;
+  };
+
+  private readonly checkAvailabilityCapacity = (context: Context, bookingFlows: Flow[]): FlowResult | null => {
+    const [bookableProduct] = context.productConfig.availableProducts;
+    if (bookableProduct === undefined) {
+      return null;
+    }
+
+    const requiredReservations = bookingFlows.reduce(
+      (total, flow) => total + flow.getReservationDemand(context).reservations,
+      0,
+    );
+    if (requiredReservations === 0) {
+      return null;
+    }
+
+    const requiredUnits = requiredReservations * bookableProduct.maxUnitsPerReservation;
+    const availableUnits = bookableProduct.totalVacancy;
+    if (availableUnits >= requiredUnits) {
+      return null;
+    }
+
+    context.terminateValidation = true;
+    const error = new ValidatorError({
+      type: ErrorType.CRITICAL,
+      message:
+        `Insufficient availability to run the booking lifecycle: it needs up to ${requiredUnits} units ` +
+        `(${requiredReservations} reservations) but the supplier exposes ${availableUnits} across the ` +
+        `validation window. Widen availability (more dates/slots) or increase capacity, then re-run.`,
+    });
+    return this.buildCapacityFlowResult(error);
+  };
+
+  private readonly buildCapacityFlowResult = (error: ValidatorError): FlowResult => {
+    const scenario: ScenarioResult = {
+      name: 'Availability Capacity Check',
+      success: false,
+      validationResult: ValidationResult.FAILED,
+      request: null,
+      response: null,
+      errors: [error.mapError()],
+      description: 'Verifies the supplier has enough availability to run the booking lifecycle.',
+    };
+    return {
+      name: 'Availability Capacity',
+      success: false,
+      validationResult: ValidationResult.FAILED,
+      totalScenarios: 1,
+      succesScenarios: 0,
+      scenarios: [scenario],
+      docs: '',
+    };
   };
 }

--- a/backend/src/common/validation/supplier/services/validation/Flows/BaseFlow.ts
+++ b/backend/src/common/validation/supplier/services/validation/Flows/BaseFlow.ts
@@ -1,6 +1,6 @@
 import { Context } from '../context/Context';
 import { Scenario, ScenarioResult, ValidationResult } from '../Scenarios/Scenario';
-import { FlowResult } from './Flow';
+import { FlowResult, ReservationDemand } from './Flow';
 
 export abstract class BaseFlow {
   private readonly name: string;
@@ -12,6 +12,15 @@ export abstract class BaseFlow {
 
   public getName(): string {
     return this.name;
+  }
+
+  /**
+   * Reservations this flow makes against the available product. Defaults to none; booking flows
+   * that create reservations override this so the controller's pre-flight capacity check is
+   * accurate (see docs/reservation-availability-refactor.md).
+   */
+  public getReservationDemand(_context: Context): ReservationDemand {
+    return { reservations: 0 };
   }
 
   public getDocs(): string {

--- a/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingCancellationFlow.ts
+++ b/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingCancellationFlow.ts
@@ -5,11 +5,15 @@ import { BookingCancellationInvalidUUIDScenario } from '../../Scenarios/Booking/
 import { BookingCancellationReservationScenario } from '../../Scenarios/Booking/Cancellation/BookingCancellationReservation';
 import { BaseFlow } from '../BaseFlow';
 
-import { Flow, FlowResult } from '../Flow';
+import { Flow, FlowResult, ReservationDemand } from '../Flow';
 
 export class BookingCancellationFlow extends BaseFlow implements Flow {
   public constructor() {
     super('Booking Cancellation', docs.bookingCancellation);
+  }
+
+  public getReservationDemand(): ReservationDemand {
+    return { reservations: 2 };
   }
 
   public validate = async (context: Context): Promise<FlowResult> => {

--- a/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingConfirmationFlow.ts
+++ b/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingConfirmationFlow.ts
@@ -5,11 +5,15 @@ import { BookingConfirmationInvalidUnitIdScenario } from '../../Scenarios/Bookin
 import { BookingConfirmationInvalidUUIDScenario } from '../../Scenarios/Booking/Confirmation/BookingConfirmationInvalidUUID';
 import { BookingConfirmationUnitItemUpdateScenario } from '../../Scenarios/Booking/Confirmation/BookingConfirmationUnitItemsUpdate';
 import { BaseFlow } from '../BaseFlow';
-import { Flow, FlowResult } from '../Flow';
+import { Flow, FlowResult, ReservationDemand } from '../Flow';
 
 export class BookingConfirmationFlow extends BaseFlow implements Flow {
   public constructor() {
     super('Booking Confirmation', docs.bookingConfirmation);
+  }
+
+  public getReservationDemand(): ReservationDemand {
+    return { reservations: 3 };
   }
 
   public validate = async (context: Context): Promise<FlowResult> => {

--- a/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingExtendFlow.ts
+++ b/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingExtendFlow.ts
@@ -3,11 +3,15 @@ import { Context } from '../../context/Context';
 import { BookingReservationExtendScenario } from '../../Scenarios/Booking/Extend/BookingReservationExtend';
 import { BookingReservationExtendInvalidUUIDScenario } from '../../Scenarios/Booking/Extend/BookingReservationExtendInvalidUUID';
 import { BaseFlow } from '../BaseFlow';
-import { Flow, FlowResult } from '../Flow';
+import { Flow, FlowResult, ReservationDemand } from '../Flow';
 
 export class BookingExtendFlow extends BaseFlow implements Flow {
   public constructor() {
     super('Extend Reservation', docs.bookingReservationExtend);
+  }
+
+  public getReservationDemand(): ReservationDemand {
+    return { reservations: 1 };
   }
 
   public validate = async (context: Context): Promise<FlowResult> => {

--- a/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingGetFlow.ts
+++ b/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingGetFlow.ts
@@ -4,11 +4,15 @@ import { BookingGetBookingScenario } from '../../Scenarios/Booking/Get/BookingGe
 import { BookingGetInvalidUUIDScenario } from '../../Scenarios/Booking/Get/BookingGetInvalidUUID';
 import { BookingGetReservationScenario } from '../../Scenarios/Booking/Get/BookingGetReservation';
 import { BaseFlow } from '../BaseFlow';
-import { Flow, FlowResult } from '../Flow';
+import { Flow, FlowResult, ReservationDemand } from '../Flow';
 
 export class BookingGetFlow extends BaseFlow implements Flow {
   public constructor() {
     super('Get Booking', docs.bookingGet);
+  }
+
+  public getReservationDemand(): ReservationDemand {
+    return { reservations: 2 };
   }
 
   public validate = async (context: Context): Promise<FlowResult> => {

--- a/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingListFlow.ts
+++ b/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingListFlow.ts
@@ -4,11 +4,15 @@ import { BookingListBadRequestScenario } from '../../Scenarios/Booking/List/Book
 import { BookingListResellerReferenceScenario } from '../../Scenarios/Booking/List/BookingListResellerReference';
 import { BookingListSupplierReferenceScenario } from '../../Scenarios/Booking/List/BookingListSupplierReference';
 import { BaseFlow } from '../BaseFlow';
-import { Flow, FlowResult } from '../Flow';
+import { Flow, FlowResult, ReservationDemand } from '../Flow';
 
 export class BookingListFlow extends BaseFlow implements Flow {
   public constructor() {
     super('List Bookings', docs.bookingList);
+  }
+
+  public getReservationDemand(): ReservationDemand {
+    return { reservations: 2 };
   }
 
   public validate = async (context: Context): Promise<FlowResult> => {

--- a/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingReservationFlow.ts
+++ b/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingReservationFlow.ts
@@ -12,12 +12,16 @@ import { BookingReservationScenario } from '../../Scenarios/Booking/Reservation/
 import { BookingReservationSoldOutScenario } from '../../Scenarios/Booking/Reservation/BookingReservationSoldOutScenario';
 import { Scenario } from '../../Scenarios/Scenario';
 import { BaseFlow } from '../BaseFlow';
-import { Flow, FlowResult } from '../Flow';
+import { Flow, FlowResult, ReservationDemand } from '../Flow';
 
 export class BookingReservationFlow extends BaseFlow implements Flow {
   private readonly booker = new Booker();
   public constructor() {
     super('Booking Reservation', docs.bookingReservation);
+  }
+
+  public getReservationDemand(): ReservationDemand {
+    return { reservations: 1 };
   }
 
   public validate = async (context: Context): Promise<FlowResult> => {

--- a/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingUpdateFlow.ts
+++ b/backend/src/common/validation/supplier/services/validation/Flows/Booking/BookingUpdateFlow.ts
@@ -6,11 +6,15 @@ import { BookingUpdateProductScenario } from '../../Scenarios/Booking/Update/Boo
 import { BookingUpdateUnitItemsScenario } from '../../Scenarios/Booking/Update/BookingUpdateUnitItems';
 import { Scenario } from '../../Scenarios/Scenario';
 import { BaseFlow } from '../BaseFlow';
-import { Flow, FlowResult } from '../Flow';
+import { Flow, FlowResult, ReservationDemand } from '../Flow';
 
 export class BookingUpdateFlow extends BaseFlow implements Flow {
   public constructor() {
     super('Booking Update', docs.bookingUpdate);
+  }
+
+  public getReservationDemand(context: Context): ReservationDemand {
+    return { reservations: context.productConfig.isRebookAvailable ? 4 : 3 };
   }
 
   public validate = async (context: Context): Promise<FlowResult> => {

--- a/backend/src/common/validation/supplier/services/validation/Flows/Flow.ts
+++ b/backend/src/common/validation/supplier/services/validation/Flows/Flow.ts
@@ -4,6 +4,17 @@ import { ScenarioResult, ValidationResult } from '../Scenarios/Scenario';
 export interface Flow {
   validate: (context: Context) => Promise<FlowResult>;
   getName: () => string;
+  getReservationDemand: (context: Context) => ReservationDemand;
+}
+
+/**
+ * How many valid reservations a flow creates against the available product during a run.
+ * Declared per flow so the controller can sum demand and check availability up front
+ * (see docs/reservation-availability-refactor.md). Only count reservations that hold real
+ * inventory on `availableProducts[0]` — invalid/sold-out variants don't consume capacity.
+ */
+export interface ReservationDemand {
+  reservations: number;
 }
 
 export interface FlowResult {

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Cancellation/BookingCancellationBooking.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Cancellation/BookingCancellationBooking.ts
@@ -19,7 +19,7 @@ export class BookingCancellationBookingScenario implements Scenario {
     const [bookableProduct] = context.productConfig.availableProducts;
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,
@@ -43,7 +43,7 @@ export class BookingCancellationBookingScenario implements Scenario {
       context,
     );
 
-    if (resultConfirmation.data === null) {
+    if (!this.helper.hasUsableBooking(resultConfirmation)) {
       return this.helper.handleResult({
         result: resultConfirmation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Cancellation/BookingCancellationReservation.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Cancellation/BookingCancellationReservation.ts
@@ -19,7 +19,7 @@ export class BookingCancellationReservationScenario implements Scenario {
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
 
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Confirmation/BookingConfirmation.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Confirmation/BookingConfirmation.ts
@@ -19,7 +19,7 @@ export class BookingConfirmationScenario implements Scenario {
     const [bookableProduct] = context.productConfig.availableProducts;
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Confirmation/BookingConfirmationInvalidUnitId.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Confirmation/BookingConfirmationInvalidUnitId.ts
@@ -23,7 +23,7 @@ export class BookingConfirmationInvalidUnitIdScenario implements Scenario {
     const resultReservation = await this.booker.createReservation(bookableProduct, context, {
       unitItemsQuantity: 2,
     });
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Confirmation/BookingConfirmationUnitItemsUpdate.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Confirmation/BookingConfirmationUnitItemsUpdate.ts
@@ -19,7 +19,7 @@ export class BookingConfirmationUnitItemUpdateScenario implements Scenario {
     const [bookableProduct] = context.productConfig.availableProducts;
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context, { unitItemsQuantity: 2 });
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Extend/BookingReservationExtend.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Extend/BookingReservationExtend.ts
@@ -18,7 +18,7 @@ export class BookingReservationExtendScenario implements Scenario {
     const [bookableProduct] = context.productConfig.availableProducts;
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Get/BookingGetBooking.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Get/BookingGetBooking.ts
@@ -21,7 +21,7 @@ export class BookingGetBookingScenario implements Scenario {
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
 
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,
@@ -45,7 +45,7 @@ export class BookingGetBookingScenario implements Scenario {
       context,
     );
 
-    if (resultConfirmation.data === null) {
+    if (!this.helper.hasUsableBooking(resultConfirmation)) {
       return this.helper.handleResult({
         result: resultConfirmation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Get/BookingGetReservation.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Get/BookingGetReservation.ts
@@ -18,7 +18,7 @@ export class BookingGetReservationScenario implements Scenario {
     const [bookableProduct] = context.productConfig.availableProducts;
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/List/BookingListResellerReference.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/List/BookingListResellerReference.ts
@@ -20,7 +20,7 @@ export class BookingListResellerReferenceScenario implements Scenario {
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
 
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,
@@ -41,7 +41,7 @@ export class BookingListResellerReferenceScenario implements Scenario {
       context,
     );
 
-    if (resultConfirmation.data === null) {
+    if (!this.helper.hasUsableBooking(resultConfirmation)) {
       return this.helper.handleResult({
         result: resultConfirmation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/List/BookingListSupplierReference.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/List/BookingListSupplierReference.ts
@@ -21,7 +21,7 @@ export class BookingListSupplierReferenceScenario implements Scenario {
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
 
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,
@@ -42,7 +42,7 @@ export class BookingListSupplierReferenceScenario implements Scenario {
       context,
     );
 
-    if (resultConfirmation.data === null) {
+    if (!this.helper.hasUsableBooking(resultConfirmation)) {
       return this.helper.handleResult({
         result: resultConfirmation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Update/BookingUpdateContact.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Update/BookingUpdateContact.ts
@@ -19,7 +19,7 @@ export class BookingUpdateContactScenario implements Scenario {
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
 
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Update/BookingUpdateDate.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Update/BookingUpdateDate.ts
@@ -20,7 +20,7 @@ export class BookingUpdateDateScenario implements Scenario {
 
     const resultReservation = await this.booker.createReservation(bookableProduct, context);
 
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Update/BookingUpdateProduct.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Update/BookingUpdateProduct.ts
@@ -19,7 +19,7 @@ export class BookingUpdateProductScenario implements Scenario {
 
     const resultReservation = await this.booker.createReservation(bookableProduct1, context);
 
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Update/BookingUpdateUnitItems.ts
+++ b/backend/src/common/validation/supplier/services/validation/Scenarios/Booking/Update/BookingUpdateUnitItems.ts
@@ -20,7 +20,7 @@ export class BookingUpdateUnitItemsScenario implements Scenario {
     const resultReservation = await this.booker.createReservation(bookableProduct, context, {
       unitItemsQuantity: 2,
     });
-    if (resultReservation.data === null) {
+    if (!this.helper.hasUsableBooking(resultReservation)) {
       return this.helper.handleResult({
         result: resultReservation,
         name,

--- a/backend/src/common/validation/supplier/services/validation/context/ProductBookable.ts
+++ b/backend/src/common/validation/supplier/services/validation/context/ProductBookable.ts
@@ -9,30 +9,39 @@ interface GetAvailabilityIDData {
   omitID: string | null;
 }
 
+/** An available availability slot and its spare capacity. `Infinity` means unlimited (FREESALE). */
+export interface AvailabilitySlot {
+  id: string;
+  vacancies: number;
+}
+
 export class ProductBookable {
   public product: Product;
-  private readonly _availabilityIdAvailable: string[] = [];
+  private readonly _availabilitySlots: AvailabilitySlot[];
+  private readonly _remainingVacancy: Map<string, number>;
+  private _slotCursor = 0;
   private readonly _availabilityIdSoldOut: string | null;
   public constructor({
     product,
-    availabilityIdAvailable,
+    availabilitySlots,
     availabilityIdSoldOut,
   }: {
     product: Product;
-    availabilityIdAvailable: string[] | null;
+    availabilitySlots: AvailabilitySlot[] | null;
     availabilityIdSoldOut: string | null;
   }) {
     this.product = product;
-    this._availabilityIdAvailable = availabilityIdAvailable ?? [];
+    this._availabilitySlots = availabilitySlots ?? [];
+    this._remainingVacancy = new Map(this._availabilitySlots.map((slot) => [slot.id, slot.vacancies]));
     this._availabilityIdSoldOut = availabilityIdSoldOut;
   }
 
-  public get availabilityIdAvailable(): string[] {
-    return this._availabilityIdAvailable;
+  public get availabilitySlots(): AvailabilitySlot[] {
+    return this._availabilitySlots;
   }
 
-  public get randomAvailabilityID(): string {
-    return this.pickRandomAvailabilityID(this._availabilityIdAvailable);
+  public get availabilityIdAvailable(): string[] {
+    return this._availabilitySlots.map((slot) => slot.id);
   }
 
   public get availabilityIdSoldOut(): string | null {
@@ -44,19 +53,58 @@ export class ProductBookable {
   }
 
   public get isAvailable(): boolean {
-    return this._availabilityIdAvailable?.length > 0;
+    return this._availabilitySlots.length > 0;
   }
 
   public get hasMultipleAvailabilities(): boolean {
-    return this._availabilityIdAvailable?.length === 2;
+    return this._availabilitySlots.length === 2;
   }
 
-  public getAvialabilityID = (data: GetAvailabilityIDData): string => {
-    return this.pickRandomAvailabilityID(this._availabilityIdAvailable.filter((id) => id !== data.omitID));
+  /** Total spare capacity across all available slots (`Infinity` if any slot is unlimited). */
+  public get totalVacancy(): number {
+    return this._availabilitySlots.reduce((sum, slot) => sum + slot.vacancies, 0);
+  }
+
+  /** Upper bound on units a single valid reservation holds — see {@link getValidUnitItems}. */
+  public get maxUnitsPerReservation(): number {
+    return this.getOption().restrictions.maxUnits ?? 5;
+  }
+
+  public get randomAvailabilityID(): string {
+    return this.reserveSlot();
+  }
+
+  /**
+   * Allocate an availability slot that can still hold `units`, decrement its tracked remaining
+   * vacancy, and rotate across slots so reservations spread out instead of exhausting one slot.
+   * The controller's pre-flight capacity check is expected to guarantee enough capacity; if a run
+   * still over-subscribes, this falls back to the slot with the most remaining vacancy.
+   */
+  public reserveSlot = (units = 1, omitID: string | null = null): string => {
+    const candidates = this._availabilitySlots.filter((slot) => slot.id !== omitID);
+    if (candidates.length === 0) {
+      return this._availabilitySlots[0]?.id ?? '';
+    }
+
+    for (let offset = 0; offset < candidates.length; offset++) {
+      const slot = candidates[(this._slotCursor + offset) % candidates.length];
+      const remaining = this._remainingVacancy.get(slot.id) ?? 0;
+      if (remaining >= units) {
+        this._remainingVacancy.set(slot.id, remaining - units);
+        this._slotCursor = (this._slotCursor + offset + 1) % candidates.length;
+        return slot.id;
+      }
+    }
+
+    const best = candidates.reduce((a, b) =>
+      (this._remainingVacancy.get(b.id) ?? 0) > (this._remainingVacancy.get(a.id) ?? 0) ? b : a,
+    );
+    this._remainingVacancy.set(best.id, (this._remainingVacancy.get(best.id) ?? 0) - units);
+    return best.id;
   };
 
-  private readonly pickRandomAvailabilityID = (array: string[]): string => {
-    return array[new PseudoRandomGenerator(array.length).nextInt(0, array.length - 1)];
+  public getAvialabilityID = (data: GetAvailabilityIDData): string => {
+    return this.reserveSlot(1, data.omitID);
   };
 
   public getValidUnitItems = (data?: GetUnitItemsData): BookingUnitItem[] => {

--- a/backend/src/common/validation/supplier/services/validation/context/__tests__/ProductBookable.test.ts
+++ b/backend/src/common/validation/supplier/services/validation/context/__tests__/ProductBookable.test.ts
@@ -1,0 +1,138 @@
+import { Product, UnitType } from '@octocloud/types';
+import { describe, expect, it } from 'vitest';
+import { ProductBookable } from '../ProductBookable';
+
+const buildProduct = (maxUnits: number | undefined = 6): Product =>
+  ({
+    options: [
+      {
+        default: true,
+        id: 'DEFAULT',
+        restrictions: { minUnits: 1, maxUnits },
+        units: [{ id: 'adult', type: UnitType.ADULT }],
+      },
+    ],
+  }) as unknown as Product;
+
+describe('ProductBookable', () => {
+  describe('reserveSlot', () => {
+    it('spreads reservations across slots instead of reusing one', () => {
+      const bookable = new ProductBookable({
+        product: buildProduct(),
+        availabilityIdSoldOut: null,
+        availabilitySlots: [
+          { id: 'a', vacancies: 10 },
+          { id: 'b', vacancies: 10 },
+          { id: 'c', vacancies: 10 },
+        ],
+      });
+
+      const picked = [bookable.reserveSlot(1), bookable.reserveSlot(1), bookable.reserveSlot(1)];
+
+      expect(new Set(picked).size).toBe(3);
+      expect(picked).toEqual(['a', 'b', 'c']);
+    });
+
+    it('skips slots without enough remaining vacancy for the requested units', () => {
+      const bookable = new ProductBookable({
+        product: buildProduct(),
+        availabilityIdSoldOut: null,
+        availabilitySlots: [
+          { id: 'small', vacancies: 1 },
+          { id: 'big', vacancies: 5 },
+        ],
+      });
+
+      // small (cursor 0) can't hold 2 units, so the allocator moves on to big.
+      expect(bookable.reserveSlot(2)).toBe('big');
+    });
+
+    it('decrements remaining vacancy as it allocates', () => {
+      const bookable = new ProductBookable({
+        product: buildProduct(),
+        availabilityIdSoldOut: null,
+        availabilitySlots: [{ id: 'only', vacancies: 3 }],
+      });
+
+      expect(bookable.reserveSlot(2)).toBe('only');
+      // 1 unit left on the only slot — still fits a 1-unit reservation.
+      expect(bookable.reserveSlot(1)).toBe('only');
+    });
+
+    it('honors omitID by allocating a different slot', () => {
+      const bookable = new ProductBookable({
+        product: buildProduct(),
+        availabilityIdSoldOut: null,
+        availabilitySlots: [
+          { id: 'a', vacancies: 10 },
+          { id: 'b', vacancies: 10 },
+        ],
+      });
+
+      expect(bookable.reserveSlot(1, 'a')).toBe('b');
+    });
+
+    it('returns empty string when there are no slots', () => {
+      const bookable = new ProductBookable({
+        product: buildProduct(),
+        availabilityIdSoldOut: null,
+        availabilitySlots: [],
+      });
+
+      expect(bookable.reserveSlot(1)).toBe('');
+    });
+  });
+
+  describe('totalVacancy', () => {
+    it('sums vacancies across slots', () => {
+      const bookable = new ProductBookable({
+        product: buildProduct(),
+        availabilityIdSoldOut: null,
+        availabilitySlots: [
+          { id: 'a', vacancies: 4 },
+          { id: 'b', vacancies: 6 },
+        ],
+      });
+
+      expect(bookable.totalVacancy).toBe(10);
+    });
+
+    it('is Infinity when any slot is unlimited', () => {
+      const bookable = new ProductBookable({
+        product: buildProduct(),
+        availabilityIdSoldOut: null,
+        availabilitySlots: [
+          { id: 'a', vacancies: 4 },
+          { id: 'freesale', vacancies: Number.POSITIVE_INFINITY },
+        ],
+      });
+
+      expect(bookable.totalVacancy).toBe(Number.POSITIVE_INFINITY);
+    });
+  });
+
+  describe('maxUnitsPerReservation', () => {
+    it('uses the option maxUnits restriction', () => {
+      const bookable = new ProductBookable({
+        product: buildProduct(8),
+        availabilityIdSoldOut: null,
+        availabilitySlots: [{ id: 'a', vacancies: 1 }],
+      });
+
+      expect(bookable.maxUnitsPerReservation).toBe(8);
+    });
+
+    it('defaults to 5 when maxUnits is not set', () => {
+      const product = {
+        options: [{ default: true, id: 'DEFAULT', restrictions: { minUnits: 1 }, units: [{ id: 'adult' }] }],
+      } as unknown as Product;
+      const bookable = new ProductBookable({
+        product,
+        availabilityIdSoldOut: null,
+        availabilitySlots: [{ id: 'a', vacancies: 1 }],
+      });
+
+      expect(bookable.maxUnitsPerReservation).toBe(5);
+    });
+  });
+});

--- a/backend/src/common/validation/supplier/services/validation/helpers/AvailabilityStatusScenarioHelper.ts
+++ b/backend/src/common/validation/supplier/services/validation/helpers/AvailabilityStatusScenarioHelper.ts
@@ -68,23 +68,23 @@ export class AvailabilityStatusScenarioHelper extends ScenarioHelper {
       data: new ProductBookable({
         product: soldOutProduct.product,
         availabilityIdSoldOut: availability?.id!,
-        availabilityIdAvailable: null,
+        availabilitySlots: null,
       }),
       error: null,
     };
   };
 
+  private readonly isBookable = (availability: Availability): boolean =>
+    availability.available &&
+    [AvailabilityStatus.AVAILABLE, AvailabilityStatus.FREESALE, AvailabilityStatus.LIMITED].includes(
+      availability.status,
+    );
+
   public findAvailableProducts = (data: ProductResults[], context: Context): ErrorResult<ProductBookable[]> => {
     const result =
       data.filter(({ result }) => {
         const availabilities = result.data ?? [];
-        const availabilitiesAvailable = availabilities.filter(
-          (availability) =>
-            (availability.status === AvailabilityStatus.AVAILABLE ||
-              AvailabilityStatus.FREESALE ||
-              AvailabilityStatus.LIMITED) &&
-            availability.available,
-        );
+        const availabilitiesAvailable = availabilities.filter(this.isBookable);
         return R.compose(R.not, R.isEmpty)(availabilitiesAvailable) && availabilitiesAvailable.length > 1;
       }) ?? null;
 
@@ -101,17 +101,15 @@ export class AvailabilityStatusScenarioHelper extends ScenarioHelper {
 
     const produts = result.map(({ product, result }) => {
       const availabilities = result.data ?? [];
-      const availabilityIDs = availabilities
-        .filter(
-          (a) =>
-            (a.status === AvailabilityStatus.AVAILABLE || AvailabilityStatus.FREESALE || AvailabilityStatus.LIMITED) &&
-            a.available,
-        )
-        .map((a) => a.id);
+      const availabilitySlots = availabilities.filter(this.isBookable).map((a) => ({
+        id: a.id,
+        // `vacancies === null` means unlimited capacity (FREESALE).
+        vacancies: a.vacancies ?? Number.POSITIVE_INFINITY,
+      }));
       return new ProductBookable({
         product,
         availabilityIdSoldOut: null,
-        availabilityIdAvailable: availabilityIDs,
+        availabilitySlots,
       });
     });
 

--- a/backend/src/common/validation/supplier/services/validation/helpers/ScenarioHelper.ts
+++ b/backend/src/common/validation/supplier/services/validation/helpers/ScenarioHelper.ts
@@ -134,6 +134,21 @@ export class ScenarioHelper {
     return !errors.some((e) => e.type === ErrorType.CRITICAL);
   };
 
+  /**
+   * Whether a reservation/confirmation result yielded a booking we can chain into the next
+   * request. Guards against a failed setup call (e.g. a sold-out reservation) whose error body is
+   * still parsed into `data` — `data === null` alone does not catch that, so we also require a
+   * successful response and a usable `uuid` (see docs/reservation-availability-refactor.md).
+   *
+   * Typed as a guard so callers keep the non-null `data` narrowing the old `data === null` check
+   * gave them.
+   */
+  public hasUsableBooking = <T extends { uuid?: string | null }>(
+    result: Result<T>,
+  ): result is Result<T> & { data: T } => {
+    return result?.response?.error == null && Boolean(result?.data?.uuid);
+  };
+
   protected shouldTerminateValidation = (
     errors: ValidatorError[],
     uuid?: string,

--- a/backend/src/common/validation/supplier/services/validation/helpers/__tests__/ScenarioHelper.test.ts
+++ b/backend/src/common/validation/supplier/services/validation/helpers/__tests__/ScenarioHelper.test.ts
@@ -1,0 +1,48 @@
+import { Booking } from '@octocloud/types';
+import { describe, expect, it } from 'vitest';
+import { Result } from '../../api/types';
+import { ScenarioHelper } from '../ScenarioHelper';
+
+const buildResult = (overrides: Partial<Result<Booking>>): Result<Booking> => ({
+  request: null,
+  response: { status: 200, body: null, error: null, headers: {} },
+  data: null,
+  ...overrides,
+});
+
+describe('ScenarioHelper.hasUsableBooking', () => {
+  const helper = new ScenarioHelper();
+
+  it('is true for a successful response carrying a uuid', () => {
+    const result = buildResult({ data: { uuid: 'abc-123' } as Booking });
+    expect(helper.hasUsableBooking(result)).toBe(true);
+  });
+
+  it('is false when the response carried an error (e.g. sold-out reservation)', () => {
+    const result = buildResult({
+      data: { error: 'UNPROCESSABLE_ENTITY', uuid: null } as unknown as Booking,
+      response: { status: 400, body: null, error: { status: 400, body: null }, headers: {} },
+    });
+    expect(helper.hasUsableBooking(result)).toBe(false);
+  });
+
+  it('is false when data is missing a uuid', () => {
+    const result = buildResult({ data: {} as Booking });
+    expect(helper.hasUsableBooking(result)).toBe(false);
+  });
+
+  it('is false when data is null', () => {
+    const result = buildResult({ data: null });
+    expect(helper.hasUsableBooking(result)).toBe(false);
+  });
+
+  it('narrows data to non-null for callers', () => {
+    const result = buildResult({ data: { uuid: 'abc-123' } as Booking });
+    if (helper.hasUsableBooking(result)) {
+      // Type-level assertion: data is non-null inside the guard.
+      expect(result.data.uuid).toBe('abc-123');
+    } else {
+      throw new Error('expected guard to pass');
+    }
+  });
+});

--- a/docs/reservation-availability-refactor.md
+++ b/docs/reservation-availability-refactor.md
@@ -1,0 +1,166 @@
+# Spec: Pre-flight reservation demand & capacity-aware slot allocation
+
+Status: proposed
+Scope: supplier validation only (`backend/src/common/validation/supplier/services/validation`)
+
+## 1. Problem
+
+The supplier-validation booking lifecycle fails against suppliers that expose **finite
+availability capacity** (observed on SIA staging, capacity 60/slot). Symptoms: late booking
+scenarios send `PATCH/GET/POST /bookings/null`, `List Bookings` returns `200 []`, all reported as
+cryptic `INVALID_BOOKING_UUID` / "bookings field must have at least 1 items".
+
+### Root cause
+
+1. **Every reservation in a run targets one single availability slot.**
+   `ProductBookable.pickRandomAvailabilityID` (`context/ProductBookable.ts:57`) creates a fresh
+   `PseudoRandomGenerator` **seeded with `array.length`** (a constant) on every call. The LCG is
+   deterministic, so the first `.next()` is always identical → the same index → the same slot for
+   every reservation. It is not random.
+
+2. **The run reserves ~15 times against that one slot**, each holding up to `maxUnits` (≤5) units.
+   Unconfirmed reservations still hold inventory. Peak demand (~15 × up to 5 = up to ~75 units) >
+   slot capacity (60) → supplier returns `400 UNPROCESSABLE_ENTITY "This availability is sold out"`.
+   Verified directly: 30 reservations × 2 units exhaust a 60-capacity slot exactly, the 31st fails.
+
+3. **Failed reservations are not detected.** `Client.parseResponse` (`api/Client.ts`) sets
+   `data = JSON.parse(text)` regardless of HTTP status, so on a 400 `data` is the *error body*
+   (truthy). The scenario guard `if (result.data === null)` never trips, and
+   `result.data.uuid` (= `null`) flows into the next request URL as `/bookings/null`.
+
+Staging itself is correct: reserve → confirm → list-by-reference all work on a fresh slot
+(verified, list returns the booking). The failures are entirely validator-side.
+
+## 2. Goals
+
+1. **Calculate the run's reservation demand up front** (number of valid reservations × units each).
+2. **Check availability against that demand** before the booking flows run; fail fast with a clear,
+   actionable error if supply is insufficient.
+3. **Allocate a sufficiently-capacious / distinct slot per reservation** so no single slot is
+   over-subscribed. Removes the deterministic single-slot bug.
+4. **Surface genuine reservation/confirmation failures legibly** ("Reservation Creation Failed" +
+   supplier error) instead of leaking `null` downstream.
+
+Non-goals: changing reseller validation; changing the OCTO scenarios' assertions; supporting
+suppliers with zero spare capacity (those will fail fast with a clear message, which is correct).
+
+## 3. Reservation demand (current, valid reservations against `availableProducts[0]`)
+
+| Flow | Scenarios that reserve real inventory | Count |
+|------|----------------------------------------|-------|
+| Booking Reservation | `reserveAvailableProduct` (invalid/sold-out variants don't consume) | 1 |
+| Booking Extend | `BookingReservationExtend` | 1 |
+| Booking Confirmation | `BookingConfirmation`, `BookingConfirmationUnitItemsUpdate`, `BookingConfirmationInvalidUnitId` | 3 |
+| Booking Update | `Date`, `UnitItems`, `Contact`, `Product`* | 4 |
+| Booking Cancellation | `Reservation`, `Booking` | 2 |
+| Booking Get | `Reservation`, `Booking` | 2 |
+| Booking List | `ResellerReference`, `SupplierReference` | 2 |
+| **Total** | | **~15** |
+
+\* `BookingUpdateProduct` also re-books onto `availableProducts[1]` via the update call.
+
+Units per reservation come from `ProductBookable.getValidUnitItems` (deterministic quantity in
+`[minUnits||1, maxUnits??5]`); `BookingUpdateUnitItems` uses quantity 2 then updates to 3.
+
+Because the count is spread across many scenario files, the demand must be **declared centrally**
+rather than re-counted by hand (see §4.1).
+
+## 4. Design
+
+### 4.1 Declare & aggregate reservation demand
+
+Introduce a single source of truth for demand instead of inferring it.
+
+- Add `ReservationDemand` = `{ reservations: number; maxUnitsPerReservation: number }`.
+- **Decision: (A) Per-flow declaration.** Each booking `Flow` exposes
+  `getReservationDemand(context): ReservationDemand` (default `{ reservations: 0, … }` on
+  `BaseFlow` for non-booking flows). The controller sums demand across the booking flows before
+  running them. Self-maintaining: adding/removing a reserving scenario updates its flow's demand in
+  the same file, so the aggregate can't silently drift.
+
+`maxUnitsPerReservation` is computed from the selected product's default option:
+`min(maxUnits ?? 5, …)` — use the actual `getValidUnitItems` quantity where fixed.
+
+### 4.2 Retain capacity in the bookable pool
+
+`AvailabilityStatusScenarioHelper.findAvailableProducts`
+(`helpers/AvailabilityStatusScenarioHelper.ts:77`) currently maps availabilities to **IDs only**.
+Change it to retain `{ id, vacancies }` (or the full `Availability`) so capacity is known.
+
+- Extend `ProductBookable` to store `availabilitySlots: { id: string; vacancies: number }[]`
+  (keep `availabilityIdAvailable` as a derived getter for back-compat).
+- Note: `findAvailableProducts` also has a latent bug — the filter
+  `status === AVAILABLE || FREESALE || LIMITED` is always-truthy (it tests the enum value, not
+  `status ===`). Fix to `[AVAILABLE, FREESALE, LIMITED].includes(status)` while here.
+
+### 4.3 Capacity-aware slot allocator (replaces the broken picker)
+
+Replace `pickRandomAvailabilityID` with a **stateful allocator** on `ProductBookable`:
+
+- `reserveSlot(units: number): string | null` — returns the id of a slot with
+  `remainingVacancy >= units`, decrements its tracked remaining vacancy, and rotates so load
+  spreads across slots; returns `null` when no slot can satisfy the request.
+- Tracks consumption in-memory for the run (reservations hold inventory whether or not confirmed).
+- `getAvialabilityID({ omitID })` (used by `BookingUpdateDate`) keeps its "pick a different slot"
+  semantics but routes through the same allocator.
+
+`Booker.createReservation` (`Booker.ts`) calls `reserveSlot(unitItems.length)` instead of
+`randomAvailabilityID`. For invalid/sold-out variants the existing override params are unchanged.
+
+### 4.4 Pre-flight availability check
+
+Add a check that runs **after the Availability flow populates `availableProducts` and before
+`BookingReservationFlow`** (new step in `Controller.validate`, or a dedicated lightweight flow):
+
+- Compute `requiredUnits = demand.reservations × demand.maxUnitsPerReservation`.
+- Compute `availableUnits = sum(vacancies)` across the chosen product's usable slots.
+- **Decision: hard-terminate.** If `availableUnits < requiredUnits` **or** fewer usable slots than
+  needed → emit one CRITICAL scenario result and set `context.terminateValidation = true`, with a
+  clear message, e.g.
+  `Insufficient availability to run the booking lifecycle: need N units across the validation
+  window, supplier exposes M. Widen availability or reduce date range.`
+- This converts today's cryptic mid-run failures into one explicit, early, actionable result.
+
+### 4.5 Detect reservation/confirmation failures (safeguard)
+
+Add a shared guard used by the **positive** booking scenarios (not the negative ones, which expect
+4xx and assert on `response.error`):
+
+- A helper `isReservationOk(result)` → `result.response?.error === null && result.data?.uuid`.
+- Positive scenarios replace `if (result.data === null)` with this guard and report
+  `Reservation Creation Failed` + the supplier error body when it fails.
+- Do **not** change `Client.parseResponse` globally (error-response validators rely on `data`
+  holding the parsed error body).
+
+## 5. Affected files
+
+- `context/ProductBookable.ts` — slot storage, allocator, remove deterministic picker.
+- `context/ProductContext.ts` / `context/Context.ts` — expose demand/pre-flight hooks if needed.
+- `helpers/AvailabilityStatusScenarioHelper.ts` — retain vacancies; fix always-truthy filter.
+- `Booker.ts` — use `reserveSlot`.
+- `Controller.ts` — insert pre-flight availability check between Availability and Reservation flows.
+- New: `ReservationDemandCalculator.ts` (+ helper for the positive-scenario guard).
+- Positive booking scenarios under `Scenarios/Booking/**` — adopt `isReservationOk` guard.
+
+## 6. Testing
+
+- Unit: `ReservationDemandCalculator` returns expected count; a guard test asserts the declared
+  count equals the number of reservation-making booking scenarios (drift detection).
+- Unit: allocator spreads across slots, respects per-slot vacancy, returns `null` when exhausted.
+- Unit: pre-flight check terminates with the clear error when `availableUnits < requiredUnits`.
+- Unit: `findAvailableProducts` filter now correctly excludes non-available statuses.
+- Integration/regression: re-run supplier validation against SIA staging
+  (`https://api.stg.siaticketing.com/api/v2/octo`) → Update / Cancellation / Get / List flows green.
+
+## 7. Rollout / risk
+
+- Behavior change is confined to supplier validation slot selection + an added early check.
+- Suppliers with ample/FREESALE inventory: unaffected (allocator just spreads; check passes).
+- Suppliers with truly insufficient capacity: now fail fast with a clear message instead of
+  misleading per-scenario errors — an improvement, but a visible change in output. Call out in PR.
+
+## 8. Decisions (resolved)
+
+1. **Demand declaration: per-flow (A).** Each booking flow declares its own demand; controller sums.
+2. **Pre-flight failure: hard-terminate** the run with one clear CRITICAL result (supply < demand).
+3. **§4.5 guard tightening ships in this PR** (low risk, makes reservation failures legible).


### PR DESCRIPTION
Supplier validation reserved every booking against a single availability slot, because ProductBookable.pickRandomAvailabilityID seeded the LCG with the slot array length (a constant) and created a fresh generator per call — so it always returned the same index. Against suppliers with finite per-slot capacity the slot sold out partway through a run; subsequent reservations failed but their error body was still parsed into `data`, so the `data === null` guards passed and a null uuid leaked into /bookings/null requests (Update/Cancel/Get/List failed with misleading INVALID_BOOKING_UUID / empty-list errors).

Changes:
- ProductBookable stores availability slots with vacancies and exposes a capacity-aware reserveSlot(units) allocator that rotates across slots and tracks remaining vacancy, replacing the deterministic single-slot picker.
- Each booking flow declares its reservation demand (getReservationDemand); the controller sums demand and runs a pre-flight capacity check before the booking lifecycle, terminating early with a clear message when the supplier cannot satisfy it.
- AvailabilityStatusScenarioHelper retains per-slot vacancies and fixes an always-truthy availability-status filter.
- ScenarioHelper.hasUsableBooking type-guards reservation/confirmation results so failed setup calls report "Reservation Creation Failed" instead of chaining a null uuid; positive booking scenarios adopt it.
- Add unit tests for the allocator and the guard; add a design doc.